### PR TITLE
Video topbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13750,6 +13750,11 @@
         }
       }
     },
+    "vue-router": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.1.tgz",
+      "integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
+    "vue-router": "^3.5.1",
     "vue-video-player": "^5.0.2",
     "vuetify": "^2.4.0",
     "vuex": "^3.4.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,116 +1,78 @@
 <template>
   <v-app>
     <v-main>
-      <div id="app" v-show="videoPathExists==false">
-        <h1>Video Player</h1>
-        <button id="chooseButton" @click="chooseVideo()"> Choose Video </button>       
+      <div id="app">
+        <router-view></router-view>
       </div>
-      <Player v-show="videoPathExists==true"/>
     </v-main>
   </v-app>
 </template>
 
 <script>
-import Player from "./components/Player.vue";
-import {ipcRenderer, remote} from 'electron'
-const {dialog} = remote
+import { ipcRenderer } from "electron";
+import { mapActions } from 'vuex';
 export default {
   name: "App",
 
-  components: {
-    Player,
-  },
-
-  data(){
-    return{
+  data() {
+    return {
       args: "arguments",
       videoPathExists: false,
-    } 
+    };
   },
-  created(){
-   ipcRenderer.on("video-path-channel", (event,videoPath) =>{
-     if(videoPath)
-       this.videoPathExists = true;
-   });
+
+  /**
+   * listen to channel  "video-path-channel". 
+   * VideoPath is selected and send over "video-path-channel" 
+   * from Home.vue component.
+   * if videoPath exists & is valid route to /player path.
+   * /player path is Player.vue component.
+   * set videoPath in vuex store.
+   * videoPath from vuex is used in PlayerCore & PlayerHeader components.
+   */
+  created() {
+    ipcRenderer.on("video-path-channel", (event, videoPath) => {
+      if (!videoPath || videoPath === "file://undefined") {
+        console.log("video not chosen");
+        this.videoPathExists = false;
+      } 
+      else {
+        this.videoPathExists = true;
+        this.setVideoPath(videoPath);
+        this.$router.push("/player");
+      }
+    });
   },
-  methods:{
-    chooseVideo(){
-      const result = dialog.showOpenDialogSync({
-        properties: ['openFile'], 
-        filters: [
-          { name: 'Movies', extensions: ['mkv', 'avi', 'mp4', 'ogg', 'webm'] },
-        ],
-        title: 'Choose Video File',   // title for Windows
-        message: 'Choose Video File', // title for Mac
-      });
-
-      let videoPath = result?.[0];
-
-      // appending 'file://' to videoPath is necessary because macos doesn't have 'file://'
-      // and we need that for file protocol to work
-      videoPath = 'file://' + videoPath;
-      ipcRenderer.send('video-path-channel', videoPath)
-    }
+  methods: {
+    ...mapActions({
+      setVideoPath: "setVideoPath",
+    })
   }
-}
-
-
+};
 </script>
 
 <style>
-body::-webkit-scrollbar{
+body::-webkit-scrollbar {
   display: none;
 }
 #app {
   margin: 0px !important;
   padding: 0px !important;
-  background-image: linear-gradient(to bottom right, rgb(23, 162, 194), rgb(167, 90, 206), rgb(209, 66, 75));
+  background-image: linear-gradient(
+    to bottom right,
+    rgb(23, 162, 194),
+    rgb(167, 90, 206),
+    rgb(209, 66, 75)
+  );
   background-repeat: no-repeat;
   background-size: cover;
   background-attachment: fixed;
   background-color: #0e153a;
 }
 @import url("https://fonts.googleapis.com/css?family=Poppins");
-h1 {
-  font-family: "Poppins";
-  color: #e2f3f5;
-  font-size: 60px;
-  font-weight: 100;
-  text-align: center;
-  margin: 0px;
-  padding-top: 70px;
-  padding-bottom: 60px;
 
-}
 /* remove orange outline */
 *:focus {
-    outline: none;
-}
-#chooseButton {
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-  font-family: "Poppins";
-  color: #e2f3f5;
-  background-image: linear-gradient(to right, #3d5af1, #21a5bd);
-  border: 0px;
-  border-radius: 10px;
-  padding-inline: 15px;
-  padding-block: 5px;
-  font-size: 25px;
-  box-shadow: 1px 3px 10px 1px #f3f169;
-}
-#chooseButton:hover {
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-  font-family: "Poppins";
-  color: #e2f3f5;
-  background-image: linear-gradient(to right, #3550da, #16a6c0);
-  border: 0px;
-  border-radius: 10px;
-  padding-inline: 15px;
-  padding-block: 5px;
-  font-size: 25px;
+  outline: none;
 }
 </style>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,6 +1,16 @@
 <template>
   <div>
-    <PlayerCore :videoPath="videoPath" />
+    <div style="position: relative">
+      <div style="position: absolute; z-index: 3;">
+        <PlayerHeader :videoPath="videoPath" />
+      </div>
+      <div style="position: absolute">
+        <PlayerCore :videoPath="videoPath" />
+      </div>
+    </div>
+    
+    
+    
   </div>
 </template>
 
@@ -8,15 +18,17 @@
 import { mapActions } from "vuex";
 import PlayerCore from "./PlayerCore";
 import { ipcRenderer } from "electron";
+import PlayerHeader from './PlayerHeader.vue';
 
 export default {
   components: {
     PlayerCore,
+    PlayerHeader,
   },
 
   data() {
     return {
-      videoPath: "asdf",
+      videoPath: "file:///Users/alek/Downloads/BigBuckBunny%205.mp4",
       videoZoom: 1,
     };
   },

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -6,10 +6,10 @@
       style="position: relative"
     >
       <div class="player-header">
-        <PlayerHeader :videoPath="videoPath" />
+        <PlayerHeader />
       </div>
-      <div style="position: absolute">
-        <PlayerCore :videoPath="videoPath" />
+      <div class="player-core">
+        <PlayerCore />
       </div>
     </div>
   </div>
@@ -18,7 +18,6 @@
 <script>
 import { mapActions } from "vuex";
 import PlayerCore from "./PlayerCore";
-import { ipcRenderer } from "electron";
 import PlayerHeader from './PlayerHeader.vue';
 
 export default {
@@ -29,12 +28,11 @@ export default {
 
   data() {
     return {
-      videoPath: "file:///Users/alek/Downloads/BigBuckBunny%205.mp4",
+      // videoPath: "file:///Users/alek/Downloads/BigBuckBunny%205.mp4",
       videoZoom: 1,
     };
   },
   created() {
-    this.addRenderer();
     this.addKeyListeners();
   },
   mounted() {
@@ -48,6 +46,7 @@ export default {
 
   methods: {
     ...mapActions({
+      setVideoPath: "setVideoPath",
       togglePlayVideo: "togglePlayVideo",
       forward: "forward",
       backward: "backward",
@@ -56,16 +55,6 @@ export default {
       toggleHeader: "playerHeader/toggleHeader",
       setPlayerHeaderHtmlElem: "playerHeader/setPlayerHeaderHtmlElem",
     }),
-    addRenderer() {
-      ipcRenderer.on("video-path-channel", (event, videoPath) => {
-        console.log(
-          " %c video path: ",
-          "color:darkblue; background-color:yellow",
-          videoPath
-        );
-        this.videoPath = videoPath;
-      });
-    },
 
     addKeyListeners() {
       window.addEventListener("keydown", (event) => {
@@ -195,5 +184,8 @@ export default {
   pointer-events: none;
   position: absolute;
   z-index: 3;
+}
+.player-core {
+  /* position: absolute; */
 }
 </style>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -191,6 +191,8 @@ export default {
 }
 
 .player-header {
+  /* force overlapping layers to pass through (ignore) click events */
+  pointer-events: none;
   position: absolute;
   z-index: 3;
 }

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,16 +1,17 @@
 <template>
   <div>
-    <div style="position: relative">
-      <div style="position: absolute; z-index: 3;">
+    <div 
+      @mousemove="showPlayerHeaderAndControls();"
+      @mouseleave="hidePlayerHeaderAndControls()"
+      style="position: relative"
+    >
+      <div class="player-header">
         <PlayerHeader :videoPath="videoPath" />
       </div>
       <div style="position: absolute">
         <PlayerCore :videoPath="videoPath" />
       </div>
     </div>
-    
-    
-    
   </div>
 </template>
 
@@ -36,6 +37,9 @@ export default {
     this.addRenderer();
     this.addKeyListeners();
   },
+  mounted() {
+    this.setPlayerHeader()
+  },
   computed: {
     player() {
       return this.$refs.videoPlayer.player;
@@ -47,7 +51,10 @@ export default {
       togglePlayVideo: "togglePlayVideo",
       forward: "forward",
       backward: "backward",
-      setGlobalVideoZoom: 'setGlobalVideoZoom'
+      setGlobalVideoZoom: 'setGlobalVideoZoom',
+      toggleControls: "toggleControls",
+      toggleHeader: "playerHeader/toggleHeader",
+      setPlayerHeaderHtmlElem: "playerHeader/setPlayerHeaderHtmlElem",
     }),
     addRenderer() {
       ipcRenderer.on("video-path-channel", (event, videoPath) => {
@@ -153,6 +160,19 @@ export default {
 
       // set global video zoom, so it can be referenced from playerCore.vue
       this.setGlobalVideoZoom(this.videoZoom);
+    },
+
+    showPlayerHeaderAndControls() {
+      this.toggleControls(true);
+      this.toggleHeader(true);
+    },
+    hidePlayerHeaderAndControls() {
+      this.toggleControls(false);
+      this.toggleHeader(false);
+    },
+    setPlayerHeader() {
+      let header = document.getElementsByClassName("player-header")[0];
+      this.setPlayerHeaderHtmlElem(header);
     }
 
   },
@@ -168,5 +188,10 @@ export default {
 @keyframes zoomOut {
   from { transform: scale(calc(var(--zoomVideoFrom)));}
   to  {  transform: scale(calc(var(--zoomVideoTo)));}
+}
+
+.player-header {
+  position: absolute;
+  z-index: 3;
 }
 </style>

--- a/src/components/PlayerCore.vue
+++ b/src/components/PlayerCore.vue
@@ -5,8 +5,6 @@
       pa-0
       ma-0
       class="video-wrapper"
-      @mousemove="showControls()"
-      @mouseleave="hideControls()"
       @drag="moveVideo($event)"
     >
       <video
@@ -177,7 +175,6 @@ export default {
 
   data() {
     return {
-      controlsShown: true,
       volume: 1,
       fullscreen: false,
       videoY: undefined,
@@ -185,7 +182,6 @@ export default {
       videoLeft: 50,
       videoTop: 50,
       nowDragging: false,
-      mouseOverControls: false,
       hideControlsTimeout: undefined,
     };
   },
@@ -223,13 +219,32 @@ export default {
         return 28;
       }
     },
+
+    controlsShown: {
+      get() {
+        return this.getControlsShown;
+      },
+      set(bool) {
+        return this.setControlsShown(bool);
+      }
+    },
+    mouseOverControls: {
+      get() {
+        return this.getMouseOverControls;
+      },
+      set(bool) {
+        return this.setMouseOverControls(bool);
+      }
+    },
     ...mapGetters({
       video: "getVideo",
       videoDuration: "getVideoDuration",
       videoCurrentTime: "getVideoCurrentTime",
       videoPaused: "getVideoPaused",
       playbackRate: "getPlaybackRate",
-      getGlobalVideoZoom: "getGlobalVideoZoom"
+      getGlobalVideoZoom: "getGlobalVideoZoom",
+      getControlsShown: "getControlsShown",
+      getMouseOverControls: "getMouseOverControls"
     }),
   },
 
@@ -250,37 +265,20 @@ export default {
       setVideoCurrentTime: "setVideoCurrentTime",
       setVideoPaused: "setVideoPaused",
       setPlaybackRate: "setPlaybackRate",
+      toggleControls: "toggleControls",
+      setControlsShown: "setControlsShown",
+      setMouseOverControls: "setMouseOverControls",
     }),
     togglePlay() {
       if(this.nowDragging == false){
         this.togglePlayVideo();
       }
-      
-      // if (this.video.paused || this.video.ended) {
-      //   this.video.play();
-      //   this.setVideoPaused(false);
-      // } else {
-      //   this.video.pause();
-      //   this.setVideoPaused(true);
-      // }
     },
     showControls() {
-      this.controlsShown = true;
-      this.$refs.videoPlayer.style.cursor = 'auto'
-
-      // if the mouse is moving clear timeout, prevent hiding controls
-      clearTimeout(this.hideControlsTimeout);
-      this.hideControlsTimeout = setTimeout( () => { 
-        this.hideControls();
-        this.$refs.videoPlayer.style.cursor = 'none'
-      } , 3000);
-      
-      // if the mouse is over controls clear timeout, prevent hiding controls
-      if(this.mouseOverControls == true) clearTimeout(this.hideControlsTimeout)
+      this.toggleControls(true);
     },
     hideControls() {
-      // setTimeout(() => (this.controlsShown = false), 0);
-      this.controlsShown = false;
+      this.toggleControls(false);
     },
     onLoadedMetadata() {
       this.setVideo(this.$refs.videoPlayer);

--- a/src/components/PlayerCore.vue
+++ b/src/components/PlayerCore.vue
@@ -8,6 +8,7 @@
       @drag="moveVideo($event)"
     >
       <video
+        v-show="getVideoPath"
         ref="videoPlayer"
         @click="togglePlay()"
         @mousedown="moveVideo($event)"
@@ -171,7 +172,6 @@
 <script>
 import { mapActions, mapGetters } from "vuex";
 export default {
-  props: ["videoPath"],
 
   data() {
     return {
@@ -184,6 +184,15 @@ export default {
       nowDragging: false,
       hideControlsTimeout: undefined,
     };
+  },
+
+  mounted(){
+    console.log('get video path from player core:', this.getVideoPath)
+    if(this.getVideoPath){
+      let source = document.createElement("source");
+      source.setAttribute("src", this.getVideoPath);
+      this.$refs.videoPlayer.appendChild(source);
+    }
   },
 
   computed: {
@@ -237,6 +246,7 @@ export default {
       }
     },
     ...mapGetters({
+      getVideoPath: "getVideoPath",
       video: "getVideo",
       videoDuration: "getVideoDuration",
       videoCurrentTime: "getVideoCurrentTime",
@@ -248,14 +258,6 @@ export default {
     }),
   },
 
-  watch: {
-    videoPath(newVal) {
-      console.log("changing video source to: ", newVal);
-      let source = document.createElement("source");
-      source.setAttribute("src", newVal);
-      this.$refs.videoPlayer.appendChild(source);
-    },
-  },
 
   methods: {
     ...mapActions({

--- a/src/components/PlayerHeader.vue
+++ b/src/components/PlayerHeader.vue
@@ -1,9 +1,15 @@
 <template>
   <div class="overlay">
     <div class="heading">
-      <v-icon color="white">mdi-arrow-left</v-icon>
-      <div> asdf </div>
-      <div> {{getVideoName}} </div>
+      <!-- 
+       any button element is triggering slider label,
+       so I had to create div like a button.
+       Problem in Vuetify. 
+      -->
+      <div class="btn" @click="backToHomeScreen()">
+        <v-icon>mdi-chevron-left</v-icon>
+      </div>
+      <div class="video-name">{{ getVideoName }}</div>
     </div>
   </div>
 </template>
@@ -14,17 +20,23 @@ export default {
 
   data() {
     return {
-      videoName: 'haha'
-    }
+      videoName: "haha",
+    };
   },
 
   computed: {
     getVideoName() {
-      let fileName = this.videoPath.split('/').pop();
-      fileName = fileName.split('.')[0];
-      fileName = fileName.replace(/%20/g, ' ');
+      let fileName = this.videoPath.split("/").pop();
+      fileName = fileName.split(".")[0];
+      fileName = fileName.replace(/%20/g, " ");
       return fileName;
-    }
+    },
+  },
+
+  methods: {
+    backToHomeScreen() {
+      console.log("go back");
+    },
   },
 
   // watch: {
@@ -33,18 +45,42 @@ export default {
   //     this.videoName = newVal;
   //   }
   // }
-}
+};
 </script>
 
 <style>
 .overlay {
-  background: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0,0,0,.4) 20%, rgba(0,0,0,.8));
-  width: 100vw; 
+  background: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0,0,0,.3) 50%, rgba(0,0,0,.8));
+  width: 100vw;
 }
 .heading {
-  color:white;
+  color: white;
   padding: 1rem 1rem;
-  display: flex
-  
+  padding-bottom: 4rem;
+  text-shadow: 1px 1px 1px rgb(0 0 0 / 50%);
+  display: flex;
+}
+.video-name {
+  padding: 0rem 1.4rem;
+  margin: auto 0rem;
+  font-size: 1.3rem;
+}
+
+.heading .v-icon {
+  --size: 30px;
+  height: var(--size);
+  font-size: var(--size);
+  width: var(--size);
+  color: white;
+}
+.btn {
+  cursor: pointer;
+  border-radius: 50%;
+}
+.btn:hover {
+  background-color: rgba(245, 245, 245, 0.195);
+}
+.btn:active {
+  background-color: rgba(245, 245, 245, 0.295);
 }
 </style>

--- a/src/components/PlayerHeader.vue
+++ b/src/components/PlayerHeader.vue
@@ -52,6 +52,8 @@ export default {
 .overlay {
   background: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0,0,0,.3) 50%, rgba(0,0,0,.8));
   width: 100vw;
+  /* force overlapping layers to pass through (ignore) click events */
+  pointer-events: none;
 }
 .heading {
   color: white;
@@ -76,6 +78,8 @@ export default {
 .btn {
   cursor: pointer;
   border-radius: 50%;
+  /* do Not ignore click event on the back button */
+  pointer-events: auto;
 }
 .btn:hover {
   background-color: rgba(245, 245, 245, 0.195);

--- a/src/components/PlayerHeader.vue
+++ b/src/components/PlayerHeader.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="overlay">
+    <div class="heading">
+      <v-icon color="white">mdi-arrow-left</v-icon>
+      <div> asdf </div>
+      <div> {{getVideoName}} </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ["videoPath"],
+
+  data() {
+    return {
+      videoName: 'haha'
+    }
+  },
+
+  computed: {
+    getVideoName() {
+      let fileName = this.videoPath.split('/').pop();
+      fileName = fileName.split('.')[0];
+      fileName = fileName.replace(/%20/g, ' ');
+      return fileName;
+    }
+  },
+
+  // watch: {
+  //   videoPath(newVal) {
+  //     console.log("new value is:", newVal)
+  //     this.videoName = newVal;
+  //   }
+  // }
+}
+</script>
+
+<style>
+.overlay {
+  background: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0,0,0,.4) 20%, rgba(0,0,0,.8));
+  width: 100vw; 
+}
+.heading {
+  color:white;
+  padding: 1rem 1rem;
+  display: flex
+  
+}
+</style>

--- a/src/components/PlayerHeader.vue
+++ b/src/components/PlayerHeader.vue
@@ -9,14 +9,15 @@
       <div class="btn" @click="backToHomeScreen()">
         <v-icon>mdi-chevron-left</v-icon>
       </div>
-      <div class="video-name">{{ getVideoName }}</div>
+
+      <div class="video-name" v-if="getVideoPath">{{ getVideoName }}</div>
     </div>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 export default {
-  props: ["videoPath"],
 
   data() {
     return {
@@ -26,31 +27,30 @@ export default {
 
   computed: {
     getVideoName() {
-      let fileName = this.videoPath.split("/").pop();
+      let fileName = this.getVideoPath.split("/").pop();
       fileName = fileName.split(".")[0];
       fileName = fileName.replace(/%20/g, " ");
       return fileName;
     },
+
+    ...mapGetters({
+      getVideoPath: "getVideoPath",
+    })
   },
 
   methods: {
     backToHomeScreen() {
       console.log("go back");
+      this.$router.push('/');
     },
   },
 
-  // watch: {
-  //   videoPath(newVal) {
-  //     console.log("new value is:", newVal)
-  //     this.videoName = newVal;
-  //   }
-  // }
 };
 </script>
 
 <style>
 .overlay {
-  background: linear-gradient(to top, rgba(255, 255, 255, 0), rgba(0,0,0,.3) 50%, rgba(0,0,0,.8));
+  background: linear-gradient(to top, rgba(0, 0, 0, 0),rgba(0,0,0,.1), rgba(0,0,0,.3) 60%, rgba(0,0,0,.6));
   width: 100vw;
   /* force overlapping layers to pass through (ignore) click events */
   pointer-events: none;

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -1,0 +1,74 @@
+<template>
+  <div>
+    <h1>Video Player</h1>
+    <button id="chooseButton" @click="chooseVideo()">Choose Video</button>
+  </div>
+</template>
+
+<script>
+import {ipcRenderer, remote} from 'electron'
+const {dialog} = remote
+export default {
+
+    methods:{
+    chooseVideo(){
+      const result = dialog.showOpenDialogSync({
+        properties: ['openFile'], 
+        filters: [
+          { name: 'Movies', extensions: ['mkv', 'avi', 'mp4', 'ogg', 'webm'] },
+        ],
+        title: 'Choose Video File',   // title for Windows
+        message: 'Choose Video File', // title for Mac
+      });
+
+      let videoPath = result?.[0];
+
+      // appending 'file://' to videoPath is necessary because macos doesn't have 'file://'
+      // and we need that for file protocol to work
+      videoPath = 'file://' + videoPath;
+      ipcRenderer.send('video-path-channel', videoPath)
+    }
+  }
+};
+</script>
+
+<style>
+h1 {
+  font-family: "Poppins";
+  color: #e2f3f5;
+  font-size: 60px;
+  font-weight: 100;
+  text-align: center;
+  margin: 0px;
+  padding-top: 70px;
+  padding-bottom: 60px;
+}
+
+#chooseButton {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+  font-family: "Poppins";
+  color: #e2f3f5;
+  background-image: linear-gradient(to right, #3d5af1, #21a5bd);
+  border: 0px;
+  border-radius: 10px;
+  padding-inline: 15px;
+  padding-block: 5px;
+  font-size: 25px;
+  box-shadow: 1px 3px 10px 1px #f3f169;
+}
+#chooseButton:hover {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+  font-family: "Poppins";
+  color: #e2f3f5;
+  background-image: linear-gradient(to right, #3550da, #16a6c0);
+  border: 0px;
+  border-radius: 10px;
+  padding-inline: 15px;
+  padding-block: 5px;
+  font-size: 25px;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@
 import Vue from 'vue'
 import App from './App.vue'
 import vuetify from './plugins/vuetify';
+import router from './router';
 import store from './store'
 
 Vue.config.productionTip = false
@@ -12,5 +13,6 @@ Vue.config.productionTip = false
 new Vue({
   vuetify,
   store,
+  router,
   render: h => h(App)
 }).$mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,22 @@
+import Vue from 'vue';
+import Router from 'vue-router';
+import Player from '../components/Player.vue'
+import Home from '../components/home/Home.vue'
+
+Vue.use(Router)
+let router = new Router({
+  routes : [
+    {
+      path: '',
+      name: 'home',
+      component: Home,
+    },
+    {
+      path: '/player',
+      name: 'player',
+      component: Player,
+    },
+  ]
+})
+
+export default router;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ import playerHeader from './modules/playerHeader'
 
 export default new Vuex.Store({
   state: {
+    videoPath: undefined,
     video: undefined,
     videoPaused: true,
     videoDuration: 0,
@@ -17,6 +18,7 @@ export default new Vuex.Store({
     mouseOverControls: false,
   },
   getters: {
+    getVideoPath: (state) => state.videoPath,
     getVideo: (state) => state.video,
     getVideoPaused: (state) => state.videoPaused,
     getVideoDuration: (state) => state.videoDuration,
@@ -36,6 +38,9 @@ export default new Vuex.Store({
         state.video.pause()
         commit('setVideoPaused', true)
       }
+    },
+    setVideoPath({commit}, videoPath){
+      commit('setVideoPath', videoPath)
     },
     setVideo({ commit }, videoHtmlElement) {
       commit('setVideo', videoHtmlElement)
@@ -63,8 +68,8 @@ export default new Vuex.Store({
     },
 
     // hiding and showing controls functions
-    toggleControls({dispatch}, bool) {
-      if(bool) {
+    toggleControls({dispatch,state}, bool) {
+      if(bool && state.video) {
         dispatch('showControls')
       }
       else {
@@ -102,6 +107,7 @@ export default new Vuex.Store({
   },
 
   mutations: {
+    setVideoPath: (state, videoPath) => state.videoPath = videoPath,
     setVideo: (state, videoHtmlElement) => state.video = videoHtmlElement,
     setVideoPaused: (state, bool) => state.videoPaused = bool,
     setVideoDuration: (state, videoDuration) => state.videoDuration = videoDuration,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,8 @@ import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
+import playerHeader from './modules/playerHeader'
+
 export default new Vuex.Store({
   state: {
     video: undefined,
@@ -11,6 +13,8 @@ export default new Vuex.Store({
     videoCurrentTime: 0,
     playbackRate: 1,
     videoZoom: 1,
+    controlsShown: true,
+    mouseOverControls: false,
   },
   getters: {
     getVideo: (state) => state.video,
@@ -19,7 +23,8 @@ export default new Vuex.Store({
     getVideoCurrentTime: (state) => state.videoCurrentTime,
     getPlaybackRate: (state) => state.playbackRate,
     getGlobalVideoZoom: (state) => state.videoZoom,
-
+    getControlsShown: (state) => state.controlsShown,
+    getMouseOverControls: (state) => state.mouseOverControls,
   },
 
   actions: {
@@ -55,8 +60,47 @@ export default new Vuex.Store({
     },
     setGlobalVideoZoom({commit}, videoZoom) {
       commit('setGlobalVideoZoom', videoZoom)
+    },
+
+    // hiding and showing controls functions
+    toggleControls({dispatch}, bool) {
+      if(bool) {
+        dispatch('showControls')
+      }
+      else {
+        dispatch('hideControls')
+      }
+    },
+
+    showControls({commit, state, dispatch}) {
+      commit('setControlsShown', true);
+
+      state.video.style.cursor = 'auto'
+
+      // if the mouse is moving clear timeout, prevent hiding controls
+      // and prevent hiding player header
+      clearTimeout(this.hideControlsTimeout);
+      this.hideControlsTimeout = setTimeout( () => { 
+        dispatch('hideControls');
+        dispatch('playerHeader/hideHeader')
+        state.video.style.cursor = 'none'
+      } , 3000);
+      
+      // if the mouse is over controls clear timeout, prevent hiding controls
+      if(state.mouseOverControls == true) clearTimeout(this.hideControlsTimeout)
+    },
+
+    hideControls({commit}) {
+      commit('setControlsShown', false);
+    },
+    setControlsShown({commit}, bool) {
+      commit('setControlsShown', bool)
+    },
+    setMouseOverControls({commit}, bool) {
+      commit('setMouseOverControls', bool);
     }
   },
+
   mutations: {
     setVideo: (state, videoHtmlElement) => state.video = videoHtmlElement,
     setVideoPaused: (state, bool) => state.videoPaused = bool,
@@ -64,8 +108,11 @@ export default new Vuex.Store({
     setVideoCurrentTime: (state, videoCurrentTime) => state.videoCurrentTime = videoCurrentTime,
     setPlaybackRate: (state, playbackRate) => state.playbackRate = playbackRate,
     setGlobalVideoZoom: (state, videoZoom) => state.videoZoom = videoZoom,
+    setControlsShown: (state, bool) => state.controlsShown = bool,
+    setMouseOverControls: (state, bool) => state.mouseOverControls = bool,
   },
 
   modules: {
+    playerHeader,
   }
 })

--- a/src/store/modules/playerHeader.js
+++ b/src/store/modules/playerHeader.js
@@ -1,0 +1,49 @@
+const state = {
+  playerHeaderHtmlElem: undefined,
+  headerShown: true,
+}
+
+const getters = {
+  getHeaderShown: (state) => state.headerShown,
+}
+
+const actions = {
+  toggleHeader({ dispatch }, bool) {
+    if (bool) {
+      dispatch('showHeader');
+    }
+    else {
+      dispatch('hideHeader');
+    }
+  },
+  showHeader({ dispatch }) {
+    state.playerHeaderHtmlElem.style.top = '0px';
+    dispatch('setHeaderShown', true);
+  },
+  hideHeader({ dispatch }) {
+    state.playerHeaderHtmlElem.style.top = '-120px';
+    dispatch('setHeaderShown', false);
+  },
+  setHeaderShown({ commit }, bool) {
+    commit('setHeaderShown', bool);
+  },
+
+  setPlayerHeaderHtmlElem({ commit }, playerHeaderHtmlElem) {
+    commit('setPlayerHeaderHtmlElem', playerHeaderHtmlElem);
+  },
+}
+
+const mutations = {
+  setHeaderShown: (state, bool) => state.mouseOverControls = bool,
+  setPlayerHeaderHtmlElem: (state, playerHeaderHtmlElem) =>
+    state.playerHeaderHtmlElem = playerHeaderHtmlElem,
+
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}


### PR DESCRIPTION
# Added player header at the top.
Player Header contains video name & go back button. Go back button router back to home screen.

- Toggle controls is moved to vuex because toggle controls & toggle header must be synchronous. This action happens in Player.vue component.
- Enabled click through player header for better drag&drop experience.
- Go back from player to home screen button added in player header. Vue Router package is installed for this. New problem with videoPath poped up. Code is refactored to solve this problem with videoPath. VideoPath is moved to vuex store. 